### PR TITLE
pass credentials and values as props

### DIFF
--- a/bin/armada-infrastructure.ts
+++ b/bin/armada-infrastructure.ts
@@ -7,6 +7,9 @@ const app = new cdk.App();
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const stack = new ArmadaInfraStack(app, 'ArmadaInfraStack', {
+  adminNodeKeyPairName: process.env.ADMIN_NODE_KEY_PAIR_NAME, // e.g. 'my-us-east-2-key-pair'
+  region: process.env.AWS_DEFAULT_REGION, // e.g. 'us-east-2'
+  availabilityZone: process.env.AWS_AVAILABILITY_ZONE, // e.g. 'us-east-2a'
   accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKeyId: process.env.AWS_SECRET_ACCESS_KEY,
   env: {

--- a/bin/armada-infrastructure.ts
+++ b/bin/armada-infrastructure.ts
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
-import { ArmadaInfrastructureStack } from '../lib/armada-infrastructure-stack';
+import { ArmadaInfraStack } from '../lib/armada-infrastructure-stack';
 
 const app = new cdk.App();
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const stack = new ArmadaInfrastructureStack(app, 'ArmadaInfrastructureStack', {
+const stack = new ArmadaInfraStack(app, 'ArmadaInfraStack', {
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKeyId: process.env.AWS_SECRET_ACCESS_KEY,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,

--- a/lib/armada-infrastructure-stack.ts
+++ b/lib/armada-infrastructure-stack.ts
@@ -17,8 +17,13 @@ import * as cognito from 'aws-cdk-lib/aws-cognito';
 import { CfnParameter, Duration } from 'aws-cdk-lib';
 import { readFileSync } from 'fs';
 
-export class ArmadaInfrastructureStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+interface ArmadaInfraStackProps extends cdk.StackProps {
+  accessKeyId: string | undefined, 
+  secretAccessKeyId: string | undefined
+}
+
+export class ArmadaInfraStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: ArmadaInfraStackProps) {
     super(scope, id, props);
 
     /****************************************************************

--- a/lib/armada-infrastructure-stack.ts
+++ b/lib/armada-infrastructure-stack.ts
@@ -21,24 +21,13 @@ interface ArmadaInfraStackProps extends cdk.StackProps {
   accessKeyId: string | undefined; 
   secretAccessKeyId: string | undefined;
   region: string | undefined;
+  availabilityZone: string | undefined;
+  adminNodeKeyPairName: string | undefined;
 }
 
 export class ArmadaInfraStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: ArmadaInfraStackProps) {
     super(scope, id, props);
-
-    /****************************************************************
-     * CDK Deploy Variables
-     ****************************************************************/
-    const accessKey = new CfnParameter(this, 'accessKey', {
-      type: 'String',
-      description: 'Please enter your access key id.',
-    });
-
-    const secretKey = new CfnParameter(this, 'secretKey', {
-      type: 'String',
-      description: 'Please enter your your secret key.',
-    });
 
     /****************************************************************
      * Virtual Private Cloud (VPC)
@@ -488,7 +477,7 @@ export class ArmadaInfraStack extends cdk.Stack {
         ec2.InstanceClass.BURSTABLE3,
         ec2.InstanceSize.MICRO
       ),
-      availabilityZone: 'us-east-1a',
+      availabilityZone: props.availabilityZone,
       securityGroups: [rdsSecurityGroup],
       multiAz: false,
       allocatedStorage: 100,
@@ -555,12 +544,12 @@ export class ArmadaInfraStack extends cdk.Stack {
         ec2.InstanceSize.SMALL
       ),
       role: adminNodeRole,
-      availabilityZone: "us-east-1a",
+      availabilityZone: props.availabilityZone,
       securityGroup: adminNodeSecurityGroup,
       machineImage: new ec2.AmazonLinuxImage({
         generation: ec2.AmazonLinuxGeneration.AMAZON_LINUX_2,
       }),
-      keyName: "armada-admin-node",
+      keyName: props.adminNodeKeyPairName,
     });
 
     adminNode.addUserData(userDataScript);

--- a/lib/armada-infrastructure-stack.ts
+++ b/lib/armada-infrastructure-stack.ts
@@ -18,12 +18,13 @@ import { CfnParameter, Duration } from 'aws-cdk-lib';
 import { readFileSync } from 'fs';
 
 interface ArmadaInfraStackProps extends cdk.StackProps {
-  accessKeyId: string | undefined, 
-  secretAccessKeyId: string | undefined
+  accessKeyId: string | undefined; 
+  secretAccessKeyId: string | undefined;
+  region: string | undefined;
 }
 
 export class ArmadaInfraStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: ArmadaInfraStackProps) {
+  constructor(scope: Construct, id: string, props: ArmadaInfraStackProps) {
     super(scope, id, props);
 
     /****************************************************************
@@ -532,7 +533,7 @@ export class ArmadaInfraStack extends cdk.Stack {
     // Secrets manager
     const adminNodeRole = new iam.Role(this, 'Admin-Node-Access-Role', {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com', {
-        region: 'us-east-1a'
+        region: props.region
       }),
       description: "Allow EC2 to access AWS Secrets Manager and RDS",
       managedPolicies: [
@@ -601,8 +602,8 @@ export class ArmadaInfraStack extends cdk.Stack {
       ],
       environment: {
         AWS_REGION: cdk.Stack.of(this).region,
-        AWS_IAM_ACCESS_KEY_ID: accessKey.valueAsString,
-        AWS_IAM_SECRET_ACCESS_KEY: secretKey.valueAsString,
+        AWS_IAM_ACCESS_KEY_ID: props.accessKeyId as string,
+        AWS_IAM_SECRET_ACCESS_KEY: props.secretAccessKeyId as string,
         DATABASE_URL: `postgresql://postgres:${databaseCredentialsSecret
           .secretValueFromJson('password')
           .unsafeUnwrap()}@${dbInstance.dbInstanceEndpointAddress}:${


### PR DESCRIPTION
removed cloudformation parameters and passed props to ArmadaInfraStack. e.g Admin must set env vars in their ~/.zshrc file